### PR TITLE
Add support for moment.duration objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ var TestClass = React.createClass({
   propTypes : {
     dateThing : momentPropTypes.momentObj,
     stringThing : momentPropTypes.momentString,
+    durationThing: momentPropTypes.momentDurationObj,
   },
 
   render : function() {
@@ -24,7 +25,8 @@ var TestClass = React.createClass({
 
 // Class Use
 <TestClass dateThing={moment()}
-           stringThing={'12-12-2014'} />
+           stringThing={'12-12-2014'}
+           durationThing={moment.duration(3, 'hours')}/>
 
 ```
 

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ var ReactPropTypeLocationNames = {
   childContext : 'child context',
 };
 
-function createMomentChecker(type, typeValidator, validator) {
+function createMomentChecker(type, typeValidator, validator, momentType) {
 
   function propValidator(isRequired, props, propName, componentName, location, propFullName) {
 
@@ -45,7 +45,7 @@ function createMomentChecker(type, typeValidator, validator) {
     if (validator(propValue)) {
       return new Error(
         'Invalid ' + location + ' `' + propName + '` of type `' + propType + '` ' +
-        'supplied to `' + componentName + '`, expected `Moment`.'
+        'supplied to `' + componentName + '`, expected `' + momentType + '`.'
       );
     }
 
@@ -64,18 +64,43 @@ module.exports = {
 
   momentObj : createMomentChecker(
     'object',
-    function (obj) { return typeof obj === 'object' },
+    function(obj) {
+      return typeof obj === 'object';
+    },
     function(value) {
       return typeof value === 'object' && !moment.isMoment(value);
-    }
+    },
+    'Moment'
   ),
 
   momentString : createMomentChecker(
     'string',
-    function (str) { return typeof str === 'string' },
+    function(str) {
+      return typeof str === 'string';
+    },
     function isMomentString(value) {
       return typeof value === 'string' && moment.utc(value).format() === 'Invalid date';
-    }
+    },
+    'Moment'
+  ),
+
+  momentDurationObj : createMomentChecker(
+    'object',
+    function(obj) {
+      return typeof obj === 'object';
+    },
+    function(value) {
+      // Since the moment library does not provide some way of identifying a duration object,
+      // we access a duration-only method and check for errors.
+      try {
+        value.asDays();
+      } catch (error) {
+        return true;
+      }
+
+      return false;
+    },
+    'duration'
   ),
 
 };

--- a/test/test.js
+++ b/test/test.js
@@ -89,7 +89,7 @@ describe('ProptypeTests', () => {
 
     });
 
-    it('should have no warnings for Missing optinal moment obj', (done) => {
+    it('should have no warnings for Missing optional moment obj', (done) => {
 
       const testElement = <TestClass/>;
       TestUtils.renderIntoDocument(testElement);
@@ -109,6 +109,7 @@ describe('ProptypeTests', () => {
       TestClass = React.createClass({
         propTypes : {
           testWrongObject : MomentPropTypes.momentObj,
+          testWrongDuration : MomentPropTypes.momentDurationObj,
         },
         render() {
           return null;
@@ -117,14 +118,16 @@ describe('ProptypeTests', () => {
 
     });
 
-    it('should have no warnings for optinal moment obj being wrong type', (done) => {
+    it('should have warnings for optional moment and duration objects being wrong type', (done) => {
 
-      const testElement = <TestClass testWrongObject={1} />;
+      const testElement = <TestClass testWrongObject={1} testWrongDuration={moment()}/>;
       TestUtils.renderIntoDocument(testElement);
 
       expect(warnings).to.be.an('array');
-      expect(warnings.length).to.equal(1);
-      expect(warnings[0]).to.contain('Invalid input type');
+      expect(warnings.length).to.equal(2);
+      expect(warnings[0]).to.include('Invalid input type');
+      expect(warnings[1]).to.include('Invalid prop');
+      expect(warnings[1]).to.include('duration');
       done();
 
     });
@@ -248,6 +251,7 @@ describe('ProptypeTests', () => {
         propTypes : {
           testValidString : MomentPropTypes.momentString,
           testValidObject : MomentPropTypes.momentObj,
+          testValidDuration : MomentPropTypes.momentDurationObj,
         },
         render() {
           return null;
@@ -257,8 +261,13 @@ describe('ProptypeTests', () => {
     });
 
     it('should have no warnings for the optional moment string', (done) => {
+      const testProps = {
+        testValidString : '12-12-2015',
+        testValidObject : moment(),
+        testValidDuration : moment.duration(),
+      };
 
-      const testElement = <TestClass testValidString={'12-12-2015'} testValidObject={moment()} />;
+      const testElement = <TestClass {...testProps} />;
       TestUtils.renderIntoDocument(testElement);
 
       expect(warnings).to.be.an('array');
@@ -277,6 +286,7 @@ describe('ProptypeTests', () => {
         propTypes : {
           testValidString : MomentPropTypes.momentString.isRequired,
           testValidObject : MomentPropTypes.momentObj.isRequired,
+          testValidDuration : MomentPropTypes.momentDurationObj.isRequired,
         },
         render() {
           return null;
@@ -286,8 +296,12 @@ describe('ProptypeTests', () => {
     });
 
     it('should have no warnings for the optional moment string', (done) => {
-
-      const testElement = <TestClass testValidString={'12-12-2015'} testValidObject={moment()} />;
+      const testProps = {
+        testValidString : '12-12-2015',
+        testValidObject : moment(),
+        testValidDuration : moment.duration(),
+      };
+      const testElement = <TestClass {...testProps} />;
       TestUtils.renderIntoDocument(testElement);
 
       expect(warnings).to.be.an('array', constructWarningsMessage(warnings));


### PR DESCRIPTION
This pull request adds a momentDurationObj propType, to support usage of moment.duration objects as props (issue #16)
