### PR TITLE
Patch 1 / npm3 addition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: node_js
 node_js:
     - "4.1"
     - "5.11"
+    - "6.1"
+    - "node"
 script:
     - npm test
     - npm run test-1.6

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "email": "caleb.morris.g@gmail.com"
   },
   "license": "MIT",
-  "dependencies": {
+  "peerDependencies": {
     "moment": ">=1.6.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
     "email": "caleb.morris.g@gmail.com"
   },
   "license": "MIT",
+  "dependencies": {
+    "moment": ">=1.6.0"
+  },
   "peerDependencies": {
     "moment": ">=1.6.0"
   },


### PR DESCRIPTION
Replacing #18

From npm3 forward the behevior of peer-dependencies has changed:

The peer-depency in previous versions would download the package if it
wasn't listed in dependencies section of package.json. This led to some
discussion and eventually to the change so that the peers are used
specificly to find conflicts in transitive dependencies and don't
download any packages unless specified in dependencies.

Announcement: http://blog.npmjs.org/post/110924823920/npm-weekly-5

Discussion: npm/npm#5080 (comment)