### PR TITLE
Changed behavior to throw a warning for required props passed nullable

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,12 @@ var ReactPropTypeLocationNames = {
   childContext : 'child context',
 };
 
+function createInvalidRequiredErrorMessage(propName, componentName, value) {
+  return new Error(
+    'The prop `' + propName + '` is marked as required in `' + componentName + '`, but its value is `' + value + '`.'
+  );
+}
+
 function createMomentChecker(type, typeValidator, validator, momentType) {
 
   function propValidator(
@@ -24,23 +30,23 @@ function createMomentChecker(type, typeValidator, validator, momentType) {
     location,
     propFullName
   ) {
-    if (isRequired) {
-      var locationName = ReactPropTypeLocationNames[ location ];
-      componentName = componentName || ANONYMOUS;
-      propFullName = propFullName || propName;
-      if (!props.hasOwnProperty(propName)) {
-        return new Error(
-          'Required ' + locationName + ' `' + propFullName +
-          '` was not specified in `' +
-          componentName + '`.'
-        );
-      }
-    }
-
     var propValue = props[ propName ];
     var propType = typeof propValue;
 
-    if (typeof propValue === 'undefined' || propValue === null) {
+    var isPropValueUndefined = typeof propValue === 'undefined';
+    var isPropValueNull = propValue === null;
+
+    if (isRequired) {
+      componentName = componentName || ANONYMOUS;
+      propFullName = propFullName || propName;
+      if (isPropValueUndefined) {
+        return createInvalidRequiredErrorMessage(propFullName, componentName, 'undefined');
+      } else if (isPropValueNull) {
+        return createInvalidRequiredErrorMessage(propFullName, componentName, 'null');
+      }
+    }
+
+    if (isPropValueUndefined || isPropValueNull) {
       return null;
     }
 

--- a/test/test.js
+++ b/test/test.js
@@ -74,12 +74,71 @@ describe('ProptypeTests', () => {
 
       expect(warnings).to.be.an('array');
       expect(warnings.length).to.equal(1);
-      expect(warnings[0]).to.contain('Required prop');
+      expect(warnings[0]).to.contain('required');
       done();
 
     });
 
   });
+
+  describe('null required object', () => {
+
+    before(() => {
+
+      TestClass = React.createClass({
+        propTypes : {
+          testRequiredObject : MomentPropTypes.momentObj.isRequired,
+        },
+        render() {
+          return null;
+        },
+      });
+
+    });
+
+    it('should have a warning for the null moment obj', (done) => {
+
+      const testElement = <TestClass testRequiredObject={null}/>;
+      TestUtils.renderIntoDocument(testElement);
+
+      expect(warnings).to.be.an('array');
+      expect(warnings.length).to.equal(1);
+      expect(warnings[0]).to.contain('required');
+      expect(warnings[0]).to.contain('null');
+      done();
+
+    });
+
+  });
+
+  // describe('undefined required object', () => {
+  //
+  //   before(() => {
+  //
+  //     TestClass = React.createClass({
+  //       propTypes : {
+  //         testRequiredObject : MomentPropTypes.momentObj.isRequired,
+  //       },
+  //       render() {
+  //         return null;
+  //       },
+  //     });
+  //
+  //   });
+  //
+  //   it('should have a warning for the undefined moment obj', (done) => {
+  //     const testElement = <TestClass testRequiredObject={undefined}/>;
+  //     TestUtils.renderIntoDocument(testElement);
+  //
+  //     expect(warnings).to.be.an('array');
+  //     expect(warnings.length).to.equal(1);
+  //     expect(warnings[0]).to.contain('required');
+  //     expect(warnings[0]).to.contain('undefined');
+  //     done();
+  //
+  //   });
+  //
+  // });
 
   describe('Missing optional object', () => {
 
@@ -163,12 +222,72 @@ describe('ProptypeTests', () => {
 
       expect(warnings).to.be.an('array');
       expect(warnings.length).to.equal(1);
-      expect(warnings[0]).to.contain('Required prop');
+      expect(warnings[0]).to.contain('required');
       done();
 
     });
 
   });
+
+  describe('null required string', () => {
+
+    before(() => {
+
+      TestClass = React.createClass({
+        propTypes : {
+          testRequiredString : MomentPropTypes.momentString.isRequired,
+        },
+        render() {
+          return null;
+        },
+      });
+
+    });
+
+    it('should have a warning for the null moment string', (done) => {
+
+      const testElement = <TestClass testRequiredString={null}/>;
+      TestUtils.renderIntoDocument(testElement);
+
+      expect(warnings).to.be.an('array');
+      expect(warnings.length).to.equal(1);
+      expect(warnings[0]).to.contain('required');
+      expect(warnings[0]).to.contain('null');
+      done();
+
+    });
+
+  });
+
+  // describe('undefined required string', () => {
+  //
+  //   before(() => {
+  //
+  //     TestClass = React.createClass({
+  //       propTypes : {
+  //         testRequiredString : MomentPropTypes.momentString.isRequired,
+  //       },
+  //       render() {
+  //         return null;
+  //       },
+  //     });
+  //
+  //   });
+  //
+  //   it('should have a warning for the undefined moment string', (done) => {
+  //
+  //     const testElement = <TestClass testRequiredString={undefined}/>;
+  //     TestUtils.renderIntoDocument(testElement);
+  //
+  //     expect(warnings).to.be.an('array');
+  //     expect(warnings.length).to.equal(1);
+  //     expect(warnings[0]).to.contain('required');
+  //     expect(warnings[0]).to.contain('undefined');
+  //     done();
+  //
+  //   });
+  //
+  // });
 
   describe('Missing optional string', () => {
 


### PR DESCRIPTION
Behavior Change: Content of `isRequired` warning now matches react common proptypes.

Odd behavior when testing
```
<TestComponent testProp={undefined}/>
```
In `ReactDOM.render` this would result in a warning for value `undefined.
When using `react-addons-test-utils`.`renderIntoDocument()` results
 in no warning.