### PR TITLE
Removed package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 coverage
 .coveralls.yml
+
+package-lock.json


### PR DESCRIPTION
The specific package logic behavior is mainly used for applications and
 provides not extra benefit being in the repo since it is not published.

The only real potential benefit and it is more a convenience. If a dev
 dependency suddenly causes a build failure I'll need to update the
 dependencies. This is something I should do regardless.