### PR TITLE
Updated lint* scripts to ignore reports

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "test-1.6": "rm -Rf ./node_modules/moment/ && npm i moment@1.6.0 && npm test",
     "test-1.7": "rm -Rf ./node_modules/moment/ && npm i moment@1.7.0 && npm test",
     "test-latest": "rm -Rf ./node_modules/moment/ && npm i moment@latest && npm test",
-    "lint": "./node_modules/.bin/eslint --ext .js .",
-    "lint-quiet": "./node_modules/.bin/eslint --ext .js --quiet .",
+    "lint": "./node_modules/.bin/eslint --ext .js . --ignore-path .gitignore",
+    "lint-quiet": "./node_modules/.bin/eslint --ext .js --quiet . --ignore-path .gitignore",
     "coverage": "./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha -- --reporter dot --recursive --compilers js:babel/register --require ./test/suppress-fallback-warning.js"
   },
   "author": {


### PR DESCRIPTION
Was catching coverage output JS if run after coverage scripts