### PR TITLE
Update index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -16,7 +16,7 @@ export namespace ReactMomentProptypes {
    * A prop-type validator with can be extended with a validation predicate.
    */
   export interface Validator<T> extends PropTypes.Validator<T | undefined | null> {
-    withPredicate(isValidMoment): Validator<T>,
+    withPredicate(isValidMoment: ValidMomentPredicate): Validator<T>,
   }
 
   /**
@@ -32,6 +32,6 @@ export namespace ReactMomentProptypes {
    * @param moment The moment being validated
    * @returns true if the Moment is valid
    */
-  function isValidMoment(moment: moment.Moment): boolean;
+  type ValidMomentPredicate = (moment: moment.Moment) => boolean;
 
 }


### PR DESCRIPTION
Avoids implicit any type errors:

```
node_modules/react-moment-proptypes/index.d.ts:19:19 - error TS7006: Parameter 'isValidMoment' implicitly has an 'any' type.

19     withPredicate(isValidMoment): Validator<T>,
```