### PR TITLE
Adjust type definitions for Validator and RequireableValidator.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -13,17 +13,18 @@ export const momentDurationObj: ReactMomentProptypes.RequireableValidator<moment
 export namespace ReactMomentProptypes {
 
   /**
-   * A prop-type validator with can be extended with a validation predicate.
+   * A prop-type validator which can be extended with a validation predicate.
    */
-  export interface Validator<T> extends PropTypes.Validator<T | undefined | null> {
-    withPredicate(isValidMoment: ValidMomentPredicate): Validator<T>,
+  export interface Validator<T> extends PropTypes.Validator<T> {
+    withPredicate(isValidMoment: ValidMomentPredicate): Validator<T>;
   }
 
   /**
    * A prop-type validator that allows for forcing requirement of the corresponding prop.
    */
-  export interface RequireableValidator<T> extends Validator<T> {
+  export interface RequireableValidator<T> extends Validator<T | undefined | null> {
     isRequired: Validator<NonNullable<T>>;
+    withPredicate(isValidMoment: ValidMomentPredicate): RequireableValidator<T>;
   }
 
   /**


### PR DESCRIPTION
Currently, any validator will use the type `T | null | undefined`, even if `isRequired` is used. (as covered in #51) 

The way I encountered this issue was using the `WeakValidationMap<P>` type from React to ensure that all validators are the correct type.

```typescript
import { WeakValidationMap } from 'react';

export type ComponentWithPropTypes<P> = {
  (props: P): JSX.Element | null;
  propTypes: WeakValidationMap<P>;
};

// somewhere else

import moment from "moment";
import propTypes from 'prop-types';
import momentPropTypes from 'react-moment-proptypes';
import { ComponentWithPropTypes } from "<path>"

type ComponentProps = {
  text: string;
  otherText?: string;
  moreText?: string;
  count: number;
  date: moment.Moment;
  date2?: moment.Moment;
}

const Component: ComponentWithPropTypes<ComponentProps> = (props) => // ...

Component.propTypes = {
  text: propTypes.string.isRequired, // fine
  otherText: propTypes.string, // fine
  otherText: propTypes.number, // error (good, it's checking the wrong type)
  count: propTypes.number, // error (good, it's required but not marked as such)
  date: momentPropTypes.momentObj.isRequired, // error (should be required, but the type is still `T | null | undefined`)
  date2: momentPropTypes.momentObj // fine
}
```

This PR changes the definitions to fix that, and brings the definitions in line with those from [prop-types](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/prop-types/index.d.ts#L40-L49).

I also added `withPredicate` to the RequireableValidator, which should fix the issue that #52 aimed to solve.

Let me know if anything needs changing 😄 